### PR TITLE
Fix reversed join() arguments for PHP 8 compatibility

### DIFF
--- a/dist/front-page.php
+++ b/dist/front-page.php
@@ -42,7 +42,7 @@
 		?>
 	
 		<a href="<?php echo $post->url; ?>" 
-			class="spotlight <?php echo join($post->classes, ' '); ?>"
+			class="spotlight <?php echo join(' ', $post->classes); ?>"
 			style="<?php echo $style; ?>">
 			<div class="spotlight__content">
 				<h2><?php echo $title; ?></h2>

--- a/src/front-page.php
+++ b/src/front-page.php
@@ -42,7 +42,7 @@
 		?>
 	
 		<a href="<?php echo $post->url; ?>" 
-			class="spotlight <?php echo join($post->classes, ' '); ?>"
+			class="spotlight <?php echo join(' ', $post->classes); ?>"
 			style="<?php echo $style; ?>">
 			<div class="spotlight__content">
 				<h2><?php echo $title; ?></h2>


### PR DESCRIPTION
`join()` was called with arguments in the wrong order (`join($array, $sep)` instead of `join($sep, $array)`). PHP 8.0 removed the old lenient behavior that accepted both orderings, so this now throws a fatal `TypeError`.

> [!NOTE]
> Generated via Claude Code.

## What Changed

- Swapped arguments in `join()` call in `src/front-page.php` and `dist/front-page.php`

## Test Plan

- [x] Front page loads without a `TypeError`
- [x] Spotlight elements render with the correct CSS classes